### PR TITLE
revert to jax lsmr

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,15 @@ For this solve, `diffqcp` provides three options:
 - LU via `lineax`, a direct method that materializes the dense coefficient matrix.
 - A direct method via `nvmath-python` / `cuDSS` that materializes the dense coefficient matrix.
 
-The default solve method is `lineax`'s LU. The LSMR solve is not packaged by default as it is not
-currently in a released `lineax` version, but it is accessible if you build `diffqcp` from source.
+The default solve method is `lineax`'s LSMR, aleit it is not packaged in a released
+`lineax` version, so `lineax `must be installed from source (*e.g.*,
+`uv add "lineax @ git+https://github.com/patrick-kidger/lineax.git"`).
 To switch between the solvers, provide `jax-lsmr`, `jax-lu`, or `nvmath-direct` (as strings) to the optional
 `solve_method` parameter of an `AbstractQCP`'s `jvp` and `vjp` methods. 
 
-**Future direction:** We're currently working on materializing the coefficient matrix as a sparse array, not a dense matrix. The `lineax` LU method would still require forming the dense matrix,
+**Future direction:** 
+1. We're currently debugging why the direct solve methods yield exploding gradients.
+2. We're currently working on materializing the coefficient matrix as a sparse array, not a dense matrix. The `lineax` LU method would still require forming the dense matrix,
 but the cuDSS backed-solve already accepts sparse arrays in CSR layout.
 
 # Installation

--- a/diffqcp/qcp.py
+++ b/diffqcp/qcp.py
@@ -136,7 +136,7 @@ class AbstractQCP(eqx.Module):
         dA: Float[BCOO | BCSR, "m n"],
         dq: Float[Array, " n"],
         db: Float[Array, " m"],
-        solve_method: str = "jax-lu"
+        solve_method: str = "jax-lsmr"
     ) -> tuple[Float[Array, " n"], Float[Array, " m"], Float[Array, " m"]]:
         """Apply the derivative of the QCP's solution map to an input perturbation.
         """
@@ -163,7 +163,7 @@ class AbstractQCP(eqx.Module):
         dy: Float[Array, " m"],
         ds: Float[Array, " m"],
         produce_output: Callable,
-        solve_method: str = "jax-lu"
+        solve_method: str = "jax-lsmr"
     ) -> tuple[
         Float[BCOO | BCSR, "n n"], Float[BCOO | BCSR, "m n"],
         Float[Array, " n"], Float[Array, " m"]]:
@@ -210,7 +210,7 @@ class AbstractQCP(eqx.Module):
         dx: Float[Array, " n"],
         dy: Float[Array, " m"],
         ds: Float[Array, " m"],
-        solve_method: str = "jax-lu"
+        solve_method: str = "jax-lsmr"
     ) -> tuple[
         Float[BCOO | BCSR, "n n"], Float[BCOO | BCSR, "m n"],
         Float[Array, " n"], Float[Array, " m"]]:
@@ -272,7 +272,7 @@ class HostQCP(AbstractQCP):
         dA: Float[BCOO, "m n"],
         dq: Float[Array, " n"],
         db: Float[Array, " m"],
-        solve_method: str = "jax-lu"
+        solve_method: str = "jax-lsmr"
     ) -> tuple[Float[Array, " n"], Float[Array, " m"], Float[Array, " m"]]:
         """Apply the derivative of the QCP's solution map to an input perturbation.
 
@@ -303,7 +303,7 @@ class HostQCP(AbstractQCP):
         dx: Float[Array, " n"],
         dy: Float[Array, " m"],
         ds: Float[Array, " m"],
-        solve_method: str = "jax-lu"
+        solve_method: str = "jax-lsmr"
     ) -> tuple[
         Float[BCSR, "n n"], Float[BCSR, "m n"],
         Float[Array, " n"], Float[Array, " m"]]:
@@ -474,7 +474,7 @@ class DeviceQCP(AbstractQCP):
         dA: Float[BCSR, "m n"],
         dq: Float[Array, " n"],
         db: Float[Array, " m"],
-        solve_method: str = "jax-lu"
+        solve_method: str = "jax-lsmr"
     ) -> tuple[Float[Array, " n"], Float[Array, " m"], Float[Array, " m"]]:
         """Apply the derivative of the QCP's solution map to an input perturbation.
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "diffqcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "Engine to compute Jacobian-vector and vector-Jacobian products for (convex) quadratic cone programs."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Via CVXPYlayers testing we're seeing the direct solvers yield exploding gradients. For now revert back to LSMR solves, which are calculating gradients that are consistent with `diffcp`.